### PR TITLE
Add Appveyor Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Automaton Logo](content/automaton_logo.png)
 <sub><sup>[Thanks to gatonegro for the logo](http://gatonegro.co/)</sup></sub>
 
-![travis build status](https://travis-ci.org/metherul/Automaton.svg?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/p0420pw6yxnfosqp?svg=true)](https://ci.appveyor.com/project/spbennett/automaton)
 
 # What is Automaton?
 > Automaton is the foundation and installer for the similarly  named _automaton framework_, which allows for modpack installation and creation in a way which respects mod author's rights. 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,4 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+build:
+  verbosity: minimal


### PR DESCRIPTION
The Travis-ci build doesn't seem to play too nicely with Visual Studio projects.  I spun up a build in Appveyor and it didn't require any code changes.  The PR below is linked to my fork, but you might prefer switching your CI system over to this one.  The build status badge will look a little happier 😄 

Feel free to use this PR as an example.  You can just swap our [your credentials](https://ci.appveyor.com/project/spbennett/automaton/settings/badges) once the repo is hooked up.

[https://www.appveyor.com/docs/](https://www.appveyor.com/docs/)
```
Add Appveyor Support
---

- Use Appveyor instead of travis-ci for native Windows build support
- Change build badge from travis-ci to Appveyor
```