### PR TITLE
Fix the missing SMIM file bug

### DIFF
--- a/src/Automaton.Model/Archive/ArchiveContents.cs
+++ b/src/Automaton.Model/Archive/ArchiveContents.cs
@@ -62,7 +62,7 @@ namespace Automaton.Model.Archive
 
             using (var archiveFile = new SevenZipExtractor.ArchiveFile(archivePath))
             {
-                archiveFile.Extract(directoryPath);
+                archiveFile.Extract(delegate (SevenZipExtractor.Entry entry) { return Path.Combine(directoryPath, entry.FileName);});
             }
 
             return;

--- a/src/Automaton.Model/Install/InstallModpack.cs
+++ b/src/Automaton.Model/Install/InstallModpack.cs
@@ -97,7 +97,7 @@ namespace Automaton.Model.Install
                     var from = Path.Combine(installPath, selection.Value.First().TargetLocation.Substring(1));
                     foreach (var e in selection.Value.Skip(1))
                     {
-                        var to = Path.Combine(installPath, selection.Value.First().TargetLocation.Substring(1));
+                        var to = Path.Combine(installPath, e.TargetLocation.Substring(1));
                         if (to != from)
                             File.Copy(from, to, true);
                     }


### PR DESCRIPTION
This should fix the missing SMIM bug. I also have a commit that makes the MO2 extraction match the extraction process for the mods so that we always talk to 7zip using the same method.