### PR TITLE
TLS/SLS Fix

### DIFF
--- a/src/Automaton.Model/NexusApi/ApiBase.cs
+++ b/src/Automaton.Model/NexusApi/ApiBase.cs
@@ -45,8 +45,7 @@ namespace Automaton.Model.NexusApi
         public bool Initialize(string apiKey = "")
         {
             ServicePointManager.Expect100Continue = true;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
+            
             _logger.WriteLine("Initializing API base");
 
             HttpClient = new HttpClient()

--- a/src/Automaton.View/App.xaml.cs
+++ b/src/Automaton.View/App.xaml.cs
@@ -13,6 +13,7 @@ namespace Automaton.View
     {
         private void Application_Startup(object sender, StartupEventArgs e)
         {
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12 | System.Net.SecurityProtocolType.Ssl3 | System.Net.SecurityProtocolType.Tls11;
             var assembly = Assembly.GetExecutingAssembly();
             var resourceName = "Automaton.View.Resources.Bin.7z-x86.dll";
 


### PR DESCRIPTION
This should fix issues that people have with TLS/SLS exceptions. Move it to the App startup so that all HTTP calls are covered, and then add support for TLS 1.1 and SSL v3 incase it needs to fall back for any reason.